### PR TITLE
Add multi-page site structure and navigation

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,13 +1,15 @@
 import React from "react";
 import { Routes, Route, Link } from "react-router-dom";
-import SimulationPage from "./SimulationPage"; // Import the new SimulationPage
-import HelpPage from "./HelpPage"; // Import the new HelpPage
+import HomePage from "./HomePage";
+import DescriptionPage from "./DescriptionPage";
+import SimulationPage from "./SimulationPage";
+import PrevisitFormPage from "./PrevisitFormPage";
+import HelpPage from "./HelpPage";
+import ReferencesPage from "./ReferencesPage";
+import ContactPage from "./ContactPage";
 
 // --- Styling ---
 const styles = {
-  // Shared styles for the overall container and header
-  // These styles are now applied to the main App component,
-  // which acts as the layout wrapper for both SimulationPage and HelpPage.
   appContainer: {
     fontFamily: "'Roboto', sans-serif",
     maxWidth: "1200px",
@@ -60,24 +62,38 @@ const styles = {
     },
   },
   icon: {
-    width: "32px", height: "32px", marginRight: "12px", color: "var(--primary-color)", flexShrink: 0,
+    width: "32px",
+    height: "32px",
+    marginRight: "12px",
+    color: "var(--primary-color)",
+    flexShrink: 0,
     "@media (max-width: 768px)": {
       marginRight: "0",
       marginBottom: "5px",
     },
   },
   titleContainer: {
-    display: "flex", flexDirection: "column", alignItems: "center",
+    display: "flex",
+    flexDirection: "column",
+    alignItems: "center",
     "@media (max-width: 768px)": {
       textAlign: "center",
     },
   },
-  title: {color: "var(--accent-color)", margin: 0, fontSize: "24px", fontWeight: "700",
+  title: {
+    color: "var(--accent-color)",
+    margin: 0,
+    fontSize: "24px",
+    fontWeight: "700",
     "@media (max-width: 768px)": {
       fontSize: "20px",
     },
   },
-  subtitle: {color: "#64748b", margin: "4px 0 0 0", fontSize: "12px", fontWeight: "400",
+  subtitle: {
+    color: "#64748b",
+    margin: "4px 0 0 0",
+    fontSize: "12px",
+    fontWeight: "400",
     "@media (max-width: 768px)": {
       fontSize: "10px",
       textAlign: "center",
@@ -91,6 +107,7 @@ const styles = {
     backgroundColor: "#eef2f7",
     borderBottom: "1px solid #dbe1e8",
     flexShrink: 0,
+    flexWrap: "wrap",
     "@media (max-width: 768px)": {
       flexDirection: "column",
       gap: "10px",
@@ -122,23 +139,61 @@ function App() {
     <div style={styles.appContainer}>
       <header style={styles.header}>
         <div style={styles.headerContent}>
-          <svg style={styles.icon} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" d="M12 20.25c4.97 0 9-3.694 9-8.25s-4.03-8.25-9-8.25S3 7.444 3 12c0 2.104.859 4.023 2.273 5.48.432.447.74 1.04.586 1.641a4.483 4.483 0 01-.923 1.785A5.969 5.969 0 006 21c1.282 0 2.47-.402 3.445-1.087.81.22 1.668.337 2.555.337z" /></svg>
+          <svg
+            style={styles.icon}
+            xmlns="http://www.w3.org/2000/svg"
+            fill="none"
+            viewBox="0 0 24 24"
+            strokeWidth={1.5}
+            stroke="currentColor"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              d="M12 20.25c4.97 0 9-3.694 9-8.25s-4.03-8.25-9-8.25S3 7.444 3 12c0 2.104.859 4.023 2.273 5.48.432.447.74 1.04.586 1.641a4.483 4.483 0 01-.923 1.785A5.969 5.969 0 006 21c1.282 0 2.47-.402 3.445-1.087.81.22 1.668.337 2.555.337z"
+            />
+          </svg>
           <div style={styles.titleContainer}>
             <h1 style={styles.title}>ECHO</h1>
-            <h2 style={styles.subtitle}>(Empowering Conversations for better Healthcare Outcomes)</h2>
+            <h2 style={styles.subtitle}>
+              (Empowering Conversations for better Healthcare Outcomes)
+            </h2>
           </div>
         </div>
       </header>
 
       <nav style={styles.navContainer}>
-        <Link to="/simulation" style={styles.navLink}>Simulation</Link>
-        <Link to="/help" style={styles.navLink}>Help & Advice</Link>
+        <Link to="/" style={styles.navLink}>
+          Home
+        </Link>
+        <Link to="/description" style={styles.navLink}>
+          Description
+        </Link>
+        <Link to="/simulation" style={styles.navLink}>
+          Simulator
+        </Link>
+        <Link to="/previsit" style={styles.navLink}>
+          Pre-Visit Form
+        </Link>
+        <Link to="/help" style={styles.navLink}>
+          Help &amp; Advice
+        </Link>
+        <Link to="/references" style={styles.navLink}>
+          References
+        </Link>
+        <Link to="/contact" style={styles.navLink}>
+          Contact
+        </Link>
       </nav>
 
       <Routes>
+        <Route path="/" element={<HomePage />} />
+        <Route path="/description" element={<DescriptionPage />} />
         <Route path="/simulation" element={<SimulationPage />} />
+        <Route path="/previsit" element={<PrevisitFormPage />} />
         <Route path="/help" element={<HelpPage />} />
-        <Route path="/" element={<SimulationPage />} /> {/* Default route */}
+        <Route path="/references" element={<ReferencesPage />} />
+        <Route path="/contact" element={<ContactPage />} />
       </Routes>
     </div>
   );

--- a/src/ContactPage.js
+++ b/src/ContactPage.js
@@ -1,0 +1,39 @@
+import React from 'react';
+
+const styles = {
+  pageContainer: {
+    flexGrow: 1,
+    padding: '20px',
+    overflowY: 'auto',
+    backgroundColor: '#f8fafc',
+  },
+  section: {
+    backgroundColor: '#ffffff',
+    border: '1px solid #dbe1e8',
+    borderRadius: '12px',
+    padding: '25px',
+    boxShadow: '0 4px 12px rgba(21,48,74,0.05)',
+    lineHeight: '1.6',
+    color: '#334155',
+  },
+  title: {
+    fontSize: '1.6em',
+    fontWeight: 'bold',
+    color: 'var(--accent-color)',
+    marginBottom: '10px',
+  },
+};
+
+function ContactPage() {
+  return (
+    <div style={styles.pageContainer}>
+      <section style={styles.section}>
+        <h2 style={styles.title}>Contact</h2>
+        <p>Email: info@example.com</p>
+        <p>Phone: (123) 456-7890</p>
+      </section>
+    </div>
+  );
+}
+
+export default ContactPage;

--- a/src/DescriptionPage.js
+++ b/src/DescriptionPage.js
@@ -1,0 +1,43 @@
+import React from 'react';
+
+const styles = {
+  pageContainer: {
+    flexGrow: 1,
+    padding: '20px',
+    overflowY: 'auto',
+    backgroundColor: '#f8fafc',
+  },
+  section: {
+    backgroundColor: '#ffffff',
+    border: '1px solid #dbe1e8',
+    borderRadius: '12px',
+    padding: '25px',
+    boxShadow: '0 4px 12px rgba(21,48,74,0.05)',
+    lineHeight: '1.6',
+    color: '#334155',
+  },
+  title: {
+    fontSize: '1.6em',
+    fontWeight: 'bold',
+    color: 'var(--accent-color)',
+    marginBottom: '10px',
+  },
+};
+
+function DescriptionPage() {
+  return (
+    <div style={styles.pageContainer}>
+      <section style={styles.section}>
+        <h2 style={styles.title}>About the Project</h2>
+        <p>
+          This site provides a suite of tools aimed at enhancing clinician–
+          patient communication. Explore the simulator to practice
+          conversations, review helpful references, and gather patient
+          information before visits.
+        </p>
+      </section>
+    </div>
+  );
+}
+
+export default DescriptionPage;

--- a/src/HomePage.js
+++ b/src/HomePage.js
@@ -1,0 +1,42 @@
+import React from 'react';
+
+const styles = {
+  pageContainer: {
+    flexGrow: 1,
+    padding: '20px',
+    overflowY: 'auto',
+    backgroundColor: '#f8fafc',
+  },
+  section: {
+    backgroundColor: '#ffffff',
+    border: '1px solid #dbe1e8',
+    borderRadius: '12px',
+    padding: '25px',
+    boxShadow: '0 4px 12px rgba(21,48,74,0.05)',
+    lineHeight: '1.6',
+    color: '#334155',
+  },
+  title: {
+    fontSize: '1.6em',
+    fontWeight: 'bold',
+    color: 'var(--accent-color)',
+    marginBottom: '10px',
+  },
+};
+
+function HomePage() {
+  return (
+    <div style={styles.pageContainer}>
+      <section style={styles.section}>
+        <h2 style={styles.title}>Welcome to ECHO</h2>
+        <p>
+          ECHO (Empowering Conversations for better Healthcare Outcomes) helps
+          clinicians build communication skills through interactive
+          simulations and practical resources.
+        </p>
+      </section>
+    </div>
+  );
+}
+
+export default HomePage;

--- a/src/PrevisitFormPage.js
+++ b/src/PrevisitFormPage.js
@@ -1,0 +1,126 @@
+import React, { useState } from 'react';
+
+const styles = {
+  pageContainer: {
+    flexGrow: 1,
+    padding: '20px',
+    overflowY: 'auto',
+    backgroundColor: '#f8fafc',
+  },
+  form: {
+    backgroundColor: '#ffffff',
+    border: '1px solid #dbe1e8',
+    borderRadius: '12px',
+    padding: '25px',
+    boxShadow: '0 4px 12px rgba(21,48,74,0.05)',
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '15px',
+  },
+  title: {
+    fontSize: '1.6em',
+    fontWeight: 'bold',
+    color: 'var(--accent-color)',
+    marginBottom: '10px',
+  },
+  label: {
+    fontWeight: 'bold',
+    color: '#334155',
+    marginBottom: '5px',
+  },
+  input: {
+    padding: '10px',
+    border: '1px solid #ccc',
+    borderRadius: '8px',
+    fontSize: '1em',
+    fontFamily: 'inherit',
+    outline: 'none',
+  },
+  textArea: {
+    padding: '10px',
+    border: '1px solid #ccc',
+    borderRadius: '8px',
+    minHeight: '80px',
+    fontSize: '1em',
+    fontFamily: 'inherit',
+    outline: 'none',
+  },
+  button: {
+    padding: '12px 25px',
+    fontSize: '1em',
+    fontWeight: 'bold',
+    backgroundColor: 'var(--primary-color)',
+    color: 'white',
+    border: 'none',
+    borderRadius: '25px',
+    cursor: 'pointer',
+    alignSelf: 'flex-start',
+  },
+};
+
+function PrevisitFormPage() {
+  const [formData, setFormData] = useState({ name: '', dob: '', concerns: '', questions: '' });
+
+  const handleChange = (e) => {
+    const { name, value } = e.target;
+    setFormData((prev) => ({ ...prev, [name]: value }));
+  };
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    console.log('Previsit form submitted:', formData);
+    alert('Form submitted. Thank you!');
+    setFormData({ name: '', dob: '', concerns: '', questions: '' });
+  };
+
+  return (
+    <div style={styles.pageContainer}>
+      <form style={styles.form} onSubmit={handleSubmit}>
+        <h2 style={styles.title}>Patient Pre-Visit Form</h2>
+
+        <label style={styles.label} htmlFor="name">Name</label>
+        <input
+          style={styles.input}
+          id="name"
+          name="name"
+          value={formData.name}
+          onChange={handleChange}
+          required
+        />
+
+        <label style={styles.label} htmlFor="dob">Date of Birth</label>
+        <input
+          style={styles.input}
+          id="dob"
+          name="dob"
+          type="date"
+          value={formData.dob}
+          onChange={handleChange}
+          required
+        />
+
+        <label style={styles.label} htmlFor="concerns">Main Concerns</label>
+        <textarea
+          style={styles.textArea}
+          id="concerns"
+          name="concerns"
+          value={formData.concerns}
+          onChange={handleChange}
+        />
+
+        <label style={styles.label} htmlFor="questions">Questions for Provider</label>
+        <textarea
+          style={styles.textArea}
+          id="questions"
+          name="questions"
+          value={formData.questions}
+          onChange={handleChange}
+        />
+
+        <button type="submit" style={styles.button}>Submit</button>
+      </form>
+    </div>
+  );
+}
+
+export default PrevisitFormPage;

--- a/src/ReferencesPage.js
+++ b/src/ReferencesPage.js
@@ -1,0 +1,45 @@
+import React from 'react';
+
+const styles = {
+  pageContainer: {
+    flexGrow: 1,
+    padding: '20px',
+    overflowY: 'auto',
+    backgroundColor: '#f8fafc',
+  },
+  section: {
+    backgroundColor: '#ffffff',
+    border: '1px solid #dbe1e8',
+    borderRadius: '12px',
+    padding: '25px',
+    boxShadow: '0 4px 12px rgba(21,48,74,0.05)',
+    lineHeight: '1.6',
+    color: '#334155',
+  },
+  title: {
+    fontSize: '1.6em',
+    fontWeight: 'bold',
+    color: 'var(--accent-color)',
+    marginBottom: '10px',
+  },
+  list: {
+    paddingLeft: '20px',
+  },
+};
+
+function ReferencesPage() {
+  return (
+    <div style={styles.pageContainer}>
+      <section style={styles.section}>
+        <h2 style={styles.title}>References</h2>
+        <ul style={styles.list}>
+          <li>Institute of Medicine. Crossing the Quality Chasm. 2001.</li>
+          <li>Epstein RM, Street RL. Patient-Centered Communication. 2007.</li>
+          <li>Stewart M. Effective Physician-Patient Communication. 1995.</li>
+        </ul>
+      </section>
+    </div>
+  );
+}
+
+export default ReferencesPage;


### PR DESCRIPTION
## Summary
- Add Home, Description, Pre-Visit Form, References, and Contact pages
- Expand navigation and routes to support new pages

## Testing
- `npm test -- --watchAll=false` *(fails: Cannot find module 'react-router-dom')*
- `NODE_OPTIONS=--experimental-vm-modules npm test -- --watchAll=false` *(fails: Cannot find module 'react-router-dom')*

------
https://chatgpt.com/codex/tasks/task_e_688aaeabe354832dbec2f05725e5999f