### PR TITLE
Add initial site pages with navigation

### DIFF
--- a/clinical-help.html
+++ b/clinical-help.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Clinical Help - Echo Medical Simulator</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <nav>
+    <ul class="main-nav">
+      <li><a href="index.html">Home</a></li>
+      <li class="dropdown">
+        <a href="#">Training</a>
+        <ul class="dropdown-content">
+          <li><a href="simulator.html">Simulator</a></li>
+          <li><a href="clinical-help.html">Clinical Help</a></li>
+          <li><a href="patient-intake.html">Patient Intake</a></li>
+        </ul>
+      </li>
+      <li><a href="help.html">Help</a></li>
+      <li><a href="references.html">References</a></li>
+    </ul>
+  </nav>
+  <main>
+    <h1>Clinical Help</h1>
+    <p>Information and resources for clinical procedures within the simulator.</p>
+  </main>
+  <footer>
+    <p>&copy; 2024 Echo Training</p>
+  </footer>
+</body>
+</html>

--- a/help.html
+++ b/help.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Help - Echo Medical Simulator</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <nav>
+    <ul class="main-nav">
+      <li><a href="index.html">Home</a></li>
+      <li class="dropdown">
+        <a href="#">Training</a>
+        <ul class="dropdown-content">
+          <li><a href="simulator.html">Simulator</a></li>
+          <li><a href="clinical-help.html">Clinical Help</a></li>
+          <li><a href="patient-intake.html">Patient Intake</a></li>
+        </ul>
+      </li>
+      <li><a href="help.html">Help</a></li>
+      <li><a href="references.html">References</a></li>
+    </ul>
+  </nav>
+  <main>
+    <h1>Help</h1>
+    <p>Resources and guidance for using the Echo simulator.</p>
+  </main>
+  <footer>
+    <p>&copy; 2024 Echo Training</p>
+  </footer>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Echo Medical Simulator</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <nav>
+    <ul class="main-nav">
+      <li><a href="index.html">Home</a></li>
+      <li class="dropdown">
+        <a href="#">Training</a>
+        <ul class="dropdown-content">
+          <li><a href="simulator.html">Simulator</a></li>
+          <li><a href="clinical-help.html">Clinical Help</a></li>
+          <li><a href="patient-intake.html">Patient Intake</a></li>
+        </ul>
+      </li>
+      <li><a href="help.html">Help</a></li>
+      <li><a href="references.html">References</a></li>
+    </ul>
+  </nav>
+  <header class="hero">
+    <h1>Echo Medical Simulator</h1>
+    <p>Training for clinical students through interactive simulation.</p>
+  </header>
+  <main>
+    <section>
+      <h2>Welcome</h2>
+      <p>Use the navigation above to explore training modules, get help, and view references for the simulator.</p>
+    </section>
+  </main>
+  <footer>
+    <p>&copy; 2024 Echo Training</p>
+  </footer>
+</body>
+</html>

--- a/patient-intake.html
+++ b/patient-intake.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Patient Intake - Echo Medical Simulator</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <nav>
+    <ul class="main-nav">
+      <li><a href="index.html">Home</a></li>
+      <li class="dropdown">
+        <a href="#">Training</a>
+        <ul class="dropdown-content">
+          <li><a href="simulator.html">Simulator</a></li>
+          <li><a href="clinical-help.html">Clinical Help</a></li>
+          <li><a href="patient-intake.html">Patient Intake</a></li>
+        </ul>
+      </li>
+      <li><a href="help.html">Help</a></li>
+      <li><a href="references.html">References</a></li>
+    </ul>
+  </nav>
+  <main>
+    <h1>Patient Intake</h1>
+    <p>Use this module to practice patient intake procedures.</p>
+  </main>
+  <footer>
+    <p>&copy; 2024 Echo Training</p>
+  </footer>
+</body>
+</html>

--- a/references.html
+++ b/references.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>References - Echo Medical Simulator</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <nav>
+    <ul class="main-nav">
+      <li><a href="index.html">Home</a></li>
+      <li class="dropdown">
+        <a href="#">Training</a>
+        <ul class="dropdown-content">
+          <li><a href="simulator.html">Simulator</a></li>
+          <li><a href="clinical-help.html">Clinical Help</a></li>
+          <li><a href="patient-intake.html">Patient Intake</a></li>
+        </ul>
+      </li>
+      <li><a href="help.html">Help</a></li>
+      <li><a href="references.html">References</a></li>
+    </ul>
+  </nav>
+  <main>
+    <h1>References</h1>
+    <ul>
+      <li>Smith J. et al. "Medical Simulation for Students" (2023).</li>
+      <li>Doe A. "Clinical Training Guidelines" (2022).</li>
+    </ul>
+  </main>
+  <footer>
+    <p>&copy; 2024 Echo Training</p>
+  </footer>
+</body>
+</html>

--- a/simulator.html
+++ b/simulator.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Simulator - Echo Medical Simulator</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <nav>
+    <ul class="main-nav">
+      <li><a href="index.html">Home</a></li>
+      <li class="dropdown">
+        <a href="#">Training</a>
+        <ul class="dropdown-content">
+          <li><a href="simulator.html">Simulator</a></li>
+          <li><a href="clinical-help.html">Clinical Help</a></li>
+          <li><a href="patient-intake.html">Patient Intake</a></li>
+        </ul>
+      </li>
+      <li><a href="help.html">Help</a></li>
+      <li><a href="references.html">References</a></li>
+    </ul>
+  </nav>
+  <main>
+    <h1>Simulator</h1>
+    <p>Launch the simulation module to practice clinical scenarios.</p>
+  </main>
+  <footer>
+    <p>&copy; 2024 Echo Training</p>
+  </footer>
+</body>
+</html>

--- a/style.css
+++ b/style.css
@@ -1,0 +1,74 @@
+:root {
+  --primary: #005f73;
+  --secondary: #0a9396;
+  --light: #e9f5f5;
+}
+
+body {
+  font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+  margin: 0;
+  background: var(--light);
+  color: #333;
+}
+
+nav {
+  background: var(--primary);
+}
+
+.main-nav {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+}
+
+.main-nav li {
+  position: relative;
+}
+
+.main-nav a {
+  color: #fff;
+  text-decoration: none;
+  padding: 1rem 1.25rem;
+  display: block;
+}
+
+.main-nav li:hover > a {
+  background: var(--secondary);
+}
+
+.dropdown-content {
+  display: none;
+  position: absolute;
+  background: var(--secondary);
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  min-width: 200px;
+  z-index: 1000;
+}
+
+.dropdown-content li a {
+  padding: 0.75rem 1rem;
+}
+
+.dropdown:hover .dropdown-content {
+  display: block;
+}
+
+.hero {
+  padding: 4rem 2rem;
+  background: #fff;
+  text-align: center;
+}
+
+main {
+  padding: 2rem;
+}
+
+footer {
+  background: var(--primary);
+  color: #fff;
+  text-align: center;
+  padding: 1rem;
+}


### PR DESCRIPTION
## Summary
- Build index, help, and references pages for the Echo medical simulator site
- Add navigation bar with dropdown links to simulator, clinical help, and patient intake modules
- Introduce shared styling with a medical color palette

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688ac889e3f8832daa3d98c6f1ba8226