### PR TITLE
style: modernize title bar font

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -19,7 +19,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
-      href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;700&display=swap"
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;600&family=Roboto:wght@400;700&display=swap"
       rel="stylesheet"
     />
     <!--

--- a/src/index.css
+++ b/src/index.css
@@ -61,6 +61,7 @@ body {
   background-color: var(--light-background);
   text-align: center;
   flex-shrink: 0;
+  font-family: 'Inter', 'Roboto', sans-serif;
 }
 
 .header-content {
@@ -86,14 +87,14 @@ body {
   color: var(--accent-color);
   margin: 0;
   font-size: 24px;
-  font-weight: 700;
+  font-weight: 600;
 }
 
 .subtitle {
   color: #64748b;
   margin: 4px 0 0 0;
   font-size: 12px;
-  font-weight: 400;
+  font-weight: 300;
 }
 
 /* Navigation styles */


### PR DESCRIPTION
## Summary
- add Inter font alongside Roboto for a more modern typeface
- apply Inter font to header and adjust title/subtitle weights

## Testing
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_688b0afca558832db1f90d097790b5bd