### PR TITLE
Add navigation and hero links for simulator, clinical question, and patient intake

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -3,7 +3,9 @@ import { Routes, Route, Link } from "react-router-dom";
 import './index.css';
 import SimulationPage from "./SimulationPage";
 import HelpPage from "./HelpPage";
-import PatientIntakeForm from "./PatientIntakeForm"
+import PatientIntakeForm from "./PatientIntakeForm";
+import ClinicalQuestionPage from "./ClinicalQuestionPage";
+import HomePage from "./HomePage";
 
 function App() {
   return (
@@ -21,14 +23,18 @@ function App() {
       </header>
 
       <nav className="nav-container">
-        <Link to="/simulation" className="nav-link">Simulation</Link>
+        <Link to="/simulation" className="nav-link">Simulator</Link>
+        <Link to="/clinical-question" className="nav-link">Clinical Question</Link>
+        <Link to="/patient-intake" className="nav-link">Patient Intake</Link>
         <Link to="/help" className="nav-link">Help & Advice</Link>
       </nav>
 
       <Routes>
         <Route path="/simulation" element={<SimulationPage />} />
+        <Route path="/clinical-question" element={<ClinicalQuestionPage />} />
+        <Route path="/patient-intake" element={<PatientIntakeForm />} />
         <Route path="/help" element={<HelpPage />} />
-        <Route path="/" element={<SimulationPage />} />
+        <Route path="/" element={<HomePage />} />
       </Routes>
     </div>
   );

--- a/src/ClinicalQuestionPage.js
+++ b/src/ClinicalQuestionPage.js
@@ -1,0 +1,12 @@
+import React from "react";
+
+function ClinicalQuestionPage() {
+  return (
+    <div style={{ padding: "20px" }}>
+      <h2>Clinical Question</h2>
+      <p>This feature is coming soon.</p>
+    </div>
+  );
+}
+
+export default ClinicalQuestionPage;

--- a/src/HomePage.js
+++ b/src/HomePage.js
@@ -1,0 +1,17 @@
+import React from "react";
+import { Link } from "react-router-dom";
+
+function HomePage() {
+  return (
+    <div className="hero-container">
+      <h2 className="hero-title">Welcome to ECHO</h2>
+      <div className="hero-links">
+        <Link to="/simulation" className="hero-link">Try Simulator</Link>
+        <Link to="/clinical-question" className="hero-link">Clinical Question</Link>
+        <Link to="/patient-intake" className="hero-link">Patient Intake</Link>
+      </div>
+    </div>
+  );
+}
+
+export default HomePage;

--- a/src/index.css
+++ b/src/index.css
@@ -122,6 +122,42 @@ body {
   background-color: #d1f7f5;
 }
 
+/* Hero section on the homepage */
+.hero-container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  padding: 60px 20px;
+}
+
+.hero-title {
+  color: var(--accent-color);
+  font-size: 2em;
+  margin-bottom: 20px;
+}
+
+.hero-links {
+  display: flex;
+  gap: 15px;
+  flex-wrap: wrap;
+  justify-content: center;
+}
+
+.hero-link {
+  text-decoration: none;
+  background-color: var(--primary-color);
+  color: white;
+  padding: 10px 20px;
+  border-radius: 25px;
+  font-weight: bold;
+  transition: background-color 0.2s;
+}
+
+.hero-link:hover {
+  background-color: var(--accent-color);
+}
+
 /* Simulation Page Styles */
 .simulation-container {
   display: flex;


### PR DESCRIPTION
## Summary
- Add Simulator, Clinical Question, and Patient Intake links in the main navigation and routing
- Introduce a homepage with a hero box linking to all three features
- Provide placeholder Clinical Question page and style hero section

## Testing
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_688b157a928c832daa13aa273c5c6d65