### PR TITLE
Add simulator navigation and hero links

### DIFF
--- a/about.html
+++ b/about.html
@@ -373,6 +373,9 @@
                 <li><a href="index.html">Home</a></li>
                 <li><a href="about.html" class="active">About</a></li>
                 <li><a href="references.html">References</a></li>
+                <li><a href="simulator.html">Simulator</a></li>
+                <li><a href="clinical-help.html">Clinical Question</a></li>
+                <li><a href="patient-intake.html">Patient Intake</a></li>
                 <li><a href="simulator-help.html">Simulator Help</a></li>
                 <li><a href="#contact">Contact</a></li>
             </ul>

--- a/clinical-help.html
+++ b/clinical-help.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Clinical Help - Echo Medical Simulator</title>
+    <title>Clinical Question - Echo Medical Simulator</title>
     <link rel="stylesheet" href="css/style.css" />
     <link rel="icon" href="favicon.ico" />
   </head>
@@ -16,7 +16,7 @@
           <a href="#">Training</a>
           <ul class="dropdown-content">
             <li><a href="simulator.html">Simulator</a></li>
-            <li><a href="clinical-help.html">Clinical Help</a></li>
+            <li><a href="clinical-help.html">Clinical Question</a></li>
             <li><a href="patient-intake.html">Patient Intake</a></li>
           </ul>
         </li>
@@ -27,7 +27,7 @@
     </nav>
     <main>
       <section class="card">
-        <h1>Clinical Help</h1>
+        <h1>Clinical Question</h1>
         <p>
           Information and resources for clinical procedures within the
           simulator.

--- a/help.html
+++ b/help.html
@@ -16,7 +16,7 @@
           <a href="#">Training</a>
           <ul class="dropdown-content">
             <li><a href="simulator.html">Simulator</a></li>
-            <li><a href="clinical-help.html">Clinical Help</a></li>
+            <li><a href="clinical-help.html">Clinical Question</a></li>
             <li><a href="patient-intake.html">Patient Intake</a></li>
           </ul>
         </li>

--- a/index.html
+++ b/index.html
@@ -99,6 +99,21 @@
             box-shadow: 0 10px 25px rgba(0,0,0,0.2);
         }
 
+        .cta-links {
+            margin-top: 15px;
+            font-size: 1rem;
+        }
+
+        .cta-links a {
+            color: #fff;
+            text-decoration: underline;
+            margin: 0 5px;
+        }
+
+        .cta-links a:hover {
+            color: #e2e8f0;
+        }
+
         /* Navigation */
         nav {
             background: rgba(255,255,255,0.95);
@@ -311,6 +326,9 @@
                 <li><a href="index.html">Home</a></li>
                 <li><a href="about.html">About</a></li>
                 <li><a href="references.html">References</a></li>
+                <li><a href="simulator.html">Simulator</a></li>
+                <li><a href="clinical-help.html">Clinical Question</a></li>
+                <li><a href="patient-intake.html">Patient Intake</a></li>
                 <li><a href="simulator-help.html">Simulator Help</a></li>
                 <li><a href="#contact">Contact</a></li>
             </ul>
@@ -322,7 +340,13 @@
         <div class="hero-content">
             <h1>Project ECHO</h1>
             <div style="font-size: 1.6rem; font-weight: 600; margin: 25px 0; color: #f0f8ff; font-style: italic;">"Because hearing is not listening."</div>
-            <a href="https://clinical-lep-simulator.web.app/" class="cta-button" target="_blank">Try the Simulator</a>
+            <div class="cta-buttons">
+                <a href="https://clinical-lep-simulator.web.app/" class="cta-button" target="_blank">Try the Simulator</a>
+                <div class="cta-links">
+                    <a href="clinical-help.html">Clinical Question</a> |
+                    <a href="patient-intake.html">Patient Intake</a>
+                </div>
+            </div>
         </div>
     </section>
 

--- a/patient-intake.html
+++ b/patient-intake.html
@@ -16,7 +16,7 @@
           <a href="#">Training</a>
           <ul class="dropdown-content">
             <li><a href="simulator.html">Simulator</a></li>
-            <li><a href="clinical-help.html">Clinical Help</a></li>
+            <li><a href="clinical-help.html">Clinical Question</a></li>
             <li><a href="patient-intake.html">Patient Intake</a></li>
           </ul>
         </li>

--- a/references.html
+++ b/references.html
@@ -329,6 +329,9 @@
                 <li><a href="index.html">Home</a></li>
                 <li><a href="about.html">About</a></li>
                 <li><a href="references.html" class="active">References</a></li>
+                <li><a href="simulator.html">Simulator</a></li>
+                <li><a href="clinical-help.html">Clinical Question</a></li>
+                <li><a href="patient-intake.html">Patient Intake</a></li>
                 <li><a href="simulator-help.html">Simulator Help</a></li>
                 <li><a href="#contact">Contact</a></li>
             </ul>

--- a/simulator-help.html
+++ b/simulator-help.html
@@ -431,7 +431,9 @@
                 <li><a href="index.html">Home</a></li>
                 <li><a href="about.html">About</a></li>
                 <li><a href="references.html">References</a></li>
-                <li><a href="https://clinical-lep-simulator.web.app/" target="_blank">Try Simulator</a></li>
+                <li><a href="simulator.html">Simulator</a></li>
+                <li><a href="clinical-help.html">Clinical Question</a></li>
+                <li><a href="patient-intake.html">Patient Intake</a></li>
                 <li><a href="simulator-help.html" class="active">Simulator Help</a></li>
             </ul>
         </div>

--- a/simulator.html
+++ b/simulator.html
@@ -16,7 +16,7 @@
           <a href="#">Training</a>
           <ul class="dropdown-content">
             <li><a href="simulator.html">Simulator</a></li>
-            <li><a href="clinical-help.html">Clinical Help</a></li>
+            <li><a href="clinical-help.html">Clinical Question</a></li>
             <li><a href="patient-intake.html">Patient Intake</a></li>
           </ul>
         </li>


### PR DESCRIPTION
## Summary
- Add Simulator, Clinical Question, and Patient Intake to navigation across pages
- Link Clinical Question and Patient Intake from homepage hero
- Rename Clinical Help page to Clinical Question

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688b17f4c414832d986958792b8efbad