### PR TITLE
Add rubric definitions to simulator help page

### DIFF
--- a/simulator-help.html
+++ b/simulator-help.html
@@ -625,6 +625,38 @@
                 </div>
             </div>
 
+            <!-- Rubric Definitions -->
+            <div class="help-section">
+                <h2 class="section-title">
+                    <div class="section-icon">📋</div>
+                    Rubric Definitions
+                </h2>
+                <div class="section-content">
+                    <div class="scoring-grid">
+                        <div class="scoring-card">
+                            <h4 class="scoring-title">Communication</h4>
+                            <p class="scoring-desc">Provider demonstrates clear, appropriate language, active listening, and effective questioning techniques. Messages are easy to understand for the patient.</p>
+                        </div>
+                        <div class="scoring-card">
+                            <h4 class="scoring-title">Trust &amp; Rapport</h4>
+                            <p class="scoring-desc">Provider establishes an empathetic and respectful connection with the patient, builds trust, and manages emotions effectively, fostering an open environment.</p>
+                        </div>
+                        <div class="scoring-card">
+                            <h4 class="scoring-title">Accuracy</h4>
+                            <p class="scoring-desc">Provider asks clinically relevant questions, gathers precise and complete information, and identifies key symptoms and history details crucial for diagnosis.</p>
+                        </div>
+                        <div class="scoring-card">
+                            <h4 class="scoring-title">Cultural Humility</h4>
+                            <p class="scoring-desc">Provider explores the patient's ideas, beliefs, and cultural context respectfully, avoids assumptions, and acknowledges cultural factors influencing health and decision-making.</p>
+                        </div>
+                        <div class="scoring-card">
+                            <h4 class="scoring-title">Shared Understanding</h4>
+                            <p class="scoring-desc">Provider ensures patient comprehension of information and the management plan, actively involves the patient in decisions, and effectively uses techniques like teach-back.</p>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
             <!-- Call to Action -->
             <div class="cta-section">
                 <h2 class="cta-title">Ready to Start Training?</h2>


### PR DESCRIPTION
## Summary
- Insert rubric definition section into simulator help page outlining key evaluation categories.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688b19e05bbc832d8d558fd108c635dc