### PR TITLE
Remove Clinical Question links from hero box

### DIFF
--- a/index.html
+++ b/index.html
@@ -99,21 +99,6 @@
             box-shadow: 0 10px 25px rgba(0,0,0,0.2);
         }
 
-        .cta-links {
-            margin-top: 15px;
-            font-size: 1rem;
-        }
-
-        .cta-links a {
-            color: #fff;
-            text-decoration: underline;
-            margin: 0 5px;
-        }
-
-        .cta-links a:hover {
-            color: #e2e8f0;
-        }
-
         /* Navigation */
         nav {
             background: rgba(255,255,255,0.95);
@@ -342,10 +327,6 @@
             <div style="font-size: 1.6rem; font-weight: 600; margin: 25px 0; color: #f0f8ff; font-style: italic;">"Because hearing is not listening."</div>
             <div class="cta-buttons">
                 <a href="https://clinical-lep-simulator.web.app/" class="cta-button" target="_blank">Try the Simulator</a>
-                <div class="cta-links">
-                    <a href="clinical-help.html">Clinical Question</a> |
-                    <a href="patient-intake.html">Patient Intake</a>
-                </div>
             </div>
         </div>
     </section>


### PR DESCRIPTION
## Summary
- remove Clinical Question and Patient Intake links from homepage hero section
- delete unused `cta-links` styling

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688b222e3ef8832d8aca5cb7a7e3f565