### PR TITLE
fix: provide rubric to Gemini prompt templates

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -255,9 +255,7 @@ async function getPhaseScoreFromGemini(geminiApiSecret, patientState, conversati
     phaseDescription,
     patientState: JSON.stringify(patientState, null, 2),
     conversationHistory: JSON.stringify(conversationHistory, null, 2),
-    rubricText: Object.entries(PHASE_RUBRIC)
-      .map(([key, value]) => `- ${key} (${value.max} pt): ${value.desc}`)
-      .join('\n'),
+    PHASE_RUBRIC,
   });
 
   const postData = JSON.stringify({
@@ -362,6 +360,7 @@ async function getGeminiResponseForInteraction(
     patientState,
     formattedHistoryForGemini,
     fidelityInstruction,
+    PHASE_RUBRIC,
   });
 
   const postData = JSON.stringify({
@@ -408,6 +407,7 @@ async function generateInjectedProviderResponse(
     phaseName,
     phaseGoalDescription,
     responseType,
+    PHASE_RUBRIC,
   });
 
   const postData = JSON.stringify({


### PR DESCRIPTION
## Summary
- ensure `PHASE_RUBRIC` is passed into all Gemini prompt templates

## Testing
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_688b7cefa154832d99b36238e2d1a488