### PR TITLE
refactor: extract constants and add simulation hook

### DIFF
--- a/src/SimulationPage.js
+++ b/src/SimulationPage.js
@@ -2,6 +2,7 @@ import React, { useState, useEffect, useRef, useCallback } from "react";
 import predefinedPatients from "./patients/predefinedPatients.json";
 import { useUserPatients } from './hooks/useUserPatients';
 import './index.css';
+import { ENCOUNTER_PHASES_CLIENT, PHASE_RUBRIC_DEFINITIONS } from './utils/constants';
 
 /**
  * ECHO Simulation Page - Modern Card-Based Design
@@ -16,64 +17,6 @@ import './index.css';
  * - Patient information display in an elegant card format
  */
 
-// ============================================================================
-// CONFIGURATION & CONSTANTS
-// ============================================================================
-
-/**
- * Client-side mirror of encounter phases for UI display
- * These phases follow the Patient-Centered/Biopsychosocial clinical model
- */
-const ENCOUNTER_PHASES_CLIENT = {
-  0: { 
-    name: "Introduction & Initial Presentation", 
-    maxScore: 0, 
-    coachIntro: (patient) => `Welcome to ECHO! You're about to meet **${patient.name}**, a **${patient.age}**-year-old. Their main complaint is: "${patient.mainComplaint}". Your goal is to conduct a complete clinical encounter adhering to the Patient-Centered / Biopsychosocial model. Let's begin with **Phase 1: Initiation and Building the Relationship**. What is your first step?`
-  },
-  1: { name: "Initiation & Building the Relationship", maxScore: 5 },
-  2: { name: "Information Gathering & History Taking", maxScore: 5 },
-  3: { name: "Physical Examination", maxScore: 5 },
-  4: { name: "Assessment & Plan / Shared Decision-Making", maxScore: 5 },
-  5: { name: "Closure", maxScore: 5 },
-  6: { name: "Encounter Complete", maxScore: 0 },
-};
-
-/**
- * Scoring rubric definitions for consistent evaluation
- * Each category is worth 1 point per phase (5 phases = 5 points max per category)
- */
-const PHASE_RUBRIC_DEFINITIONS = {
-  communication: { 
-    label: "Communication", 
-    desc: "Provider demonstrates clear, appropriate language, active listening, and effective questioning techniques. Messages are easy to understand for the patient.", 
-    max: 1,
-    icon: "💬"
-  },
-  trustRapport: { 
-    label: "Trust & Rapport", 
-    desc: "Provider establishes an empathetic and respectful connection with the patient, builds trust, and manages emotions effectively, fostering an open environment.", 
-    max: 1,
-    icon: "🤝"
-  },
-  accuracy: { 
-    label: "Accuracy", 
-    desc: "Provider asks clinically relevant questions, gathers precise and complete information, and identifies key symptoms/history details crucial for diagnosis.", 
-    max: 1,
-    icon: "🎯"
-  },
-  culturalHumility: { 
-    label: "Cultural Humility", 
-    desc: "Provider explores patient's ideas, beliefs, and cultural context respectfully, avoids assumptions, and acknowledges cultural factors influencing health/illness and decision-making.", 
-    max: 1,
-    icon: "🌍"
-  },
-  sharedUnderstanding: { 
-    label: "Shared Understanding", 
-    desc: "Provider ensures patient comprehension of information and the management plan, actively involves the patient in decisions, and effectively uses techniques like teach-back.", 
-    max: 1,
-    icon: "🔄"
-  },
-};
 
 // ============================================================================
 // MAIN COMPONENT

--- a/src/hooks/useSimulation.js
+++ b/src/hooks/useSimulation.js
@@ -1,0 +1,292 @@
+import { useState, useCallback, useEffect } from 'react';
+import predefinedPatients from '../patients/predefinedPatients.json';
+import { ENCOUNTER_PHASES_CLIENT, PHASE_RUBRIC_DEFINITIONS } from '../utils/constants';
+import { useUserPatients } from './useUserPatients';
+
+export const useSimulation = () => {
+  const [messages, setMessages] = useState([]);
+  const [conversationHistoryForAPI, setConversationHistoryForAPI] = useState([]);
+  const [patientState, setPatientState] = useState(null);
+  const [inputValue, setInputValue] = useState('');
+
+  const [isLoading, setIsLoading] = useState(false);
+  const [selectedPatientIndex, setSelectedPatientIndex] = useState('');
+  const [error, setError] = useState(null);
+  const [showCoachPanel, setShowCoachPanel] = useState(false);
+
+  const [showFullPatientInfo, setShowFullPatientInfo] = useState(false);
+  const [showScoringModal, setShowScoringModal] = useState(false);
+
+  const [encounterState, setEncounterState] = useState({
+    currentPhase: 0,
+    providerTurnCount: 0,
+    phaseScores: {},
+    currentCumulativeScore: 0,
+    totalPossibleScore: 0,
+  });
+
+  const [overallFeedback, setOverallFeedback] = useState(null);
+
+  const { userPatients, refreshUserPatients } = useUserPatients();
+
+  const functionUrl = 'https://us-central1-echo-d825e.cloudfunctions.net/echoSimulator';
+
+  const resetSimulation = useCallback(() => {
+    setIsLoading(false);
+    setMessages([]);
+    setConversationHistoryForAPI([]);
+    setPatientState(null);
+    setSelectedPatientIndex('');
+    setShowFullPatientInfo(false);
+    setShowScoringModal(false);
+    setShowCoachPanel(false);
+    setOverallFeedback(null);
+    setError(null);
+    setEncounterState({
+      currentPhase: 0,
+      providerTurnCount: 0,
+      phaseScores: {},
+      currentCumulativeScore: 0,
+      totalPossibleScore: 0,
+    });
+  }, []);
+
+  const loadPatient = useCallback((patientProfile, initialCoachMessage, initialEncounterState) => {
+    setPatientState(patientProfile);
+    setMessages([{ text: initialCoachMessage, from: 'coach' }]);
+    setConversationHistoryForAPI([]);
+    setEncounterState(initialEncounterState);
+  }, []);
+
+  const handlePredefinedPatientChange = useCallback((event) => {
+    resetSimulation();
+    const value = event.target.value;
+    setSelectedPatientIndex(value);
+
+    if (value !== '') {
+      let patient;
+      let isUserGenerated = false;
+
+      if (value.startsWith('user-')) {
+        const userId = parseInt(value.replace('user-', ''), 10);
+        patient = userPatients.find(p => p.id === userId);
+        isUserGenerated = true;
+      } else {
+        const index = parseInt(value, 10);
+        patient = predefinedPatients[index];
+      }
+
+      if (patient) {
+        const initialCoachMessage = ENCOUNTER_PHASES_CLIENT[0].coachIntro(patient);
+        setPatientState(patient);
+        setMessages([{ text: initialCoachMessage, from: 'coach' }]);
+        setConversationHistoryForAPI([]);
+        setEncounterState({
+          currentPhase: 0,
+          providerTurnCount: 0,
+          phaseScores: {},
+          currentCumulativeScore: 0,
+          totalPossibleScore: 0,
+        });
+
+        if (isUserGenerated) {
+          console.log('Loaded user-generated patient:', patient.name);
+        }
+      }
+    }
+  }, [resetSimulation, userPatients]);
+
+  const sendInteractionToServer = useCallback(async (actionType, input) => {
+    if (!patientState || isLoading) return;
+
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      const response = await fetch(functionUrl, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          action: 'interact_conversation',
+          actionType: actionType,
+          latestInput: input,
+          patientState: patientState,
+          conversationHistory: conversationHistoryForAPI,
+          encounterState: encounterState,
+        }),
+      });
+
+      if (!response.ok) {
+        const errorBody = await response.text();
+        throw new Error(`HTTP error! status: ${response.status} - ${errorBody}`);
+      }
+
+      const data = await response.json();
+      console.log('Received data from server:', data);
+
+      setPatientState(data.patientState || patientState);
+      setEncounterState(data.encounterState);
+      setOverallFeedback(data.overallFeedback);
+
+      if (data.injectedProviderResponse) {
+        setMessages((prev) => [...prev, { text: data.injectedProviderResponse, from: 'provider' }]);
+        setConversationHistoryForAPI((prev) => [...prev, { role: 'provider', parts: [{ text: data.injectedProviderResponse }] }]);
+      }
+
+      setMessages((prev) => [...prev, { text: data.simulatorResponse, from: data.from }]);
+      setConversationHistoryForAPI((prev) => [...prev, { role: data.from, parts: [{ text: data.simulatorResponse }] }]);
+
+      if (data.nextCoachMessage && data.nextCoachMessage !== data.simulatorResponse) {
+        setMessages((prev) => [...prev, { text: data.nextCoachMessage, from: 'coach' }]);
+        setConversationHistoryForAPI((prev) => [...prev, { role: 'coach', parts: [{ text: data.nextCoachMessage }] }]);
+      }
+
+    } catch (err) {
+      console.error('Failed to communicate with cloud function:', err);
+      setError(`Failed to communicate with the AI backend: ${err.message}. Please try again.`);
+      setMessages((prev) => [...prev, { text: `Sorry, an error occurred with the AI backend. Check console for details.`, from: 'coach' }]);
+
+      if (actionType === 'regular_interaction') {
+        setConversationHistoryForAPI((prev) => prev.slice(0, -1));
+      }
+    } finally {
+      setIsLoading(false);
+    }
+  }, [patientState, isLoading, conversationHistoryForAPI, encounterState, functionUrl]);
+
+  const handleSendMessage = async () => {
+    if (inputValue.trim() === '' || !patientState || isLoading || encounterState.currentPhase >= Object.keys(ENCOUNTER_PHASES_CLIENT).length - 1) {
+      if (encounterState.currentPhase >= Object.keys(ENCOUNTER_PHASES_CLIENT).length - 1) {
+        setMessages((prev) => [...prev, { text: 'The encounter is complete. Please start a new patient.', from: 'coach'}]);
+      }
+      setInputValue('');
+      return;
+    }
+
+    const providerMessageText = inputValue;
+    setMessages((prev) => [...prev, { text: providerMessageText, from: 'provider' }]);
+    setConversationHistoryForAPI((prev) => [...prev, { role: 'provider', parts: [{ text: providerMessageText }] }]);
+    setInputValue('');
+
+    await sendInteractionToServer('regular_interaction', providerMessageText);
+  };
+
+  const handleCoachTipRequest = async () => {
+    setShowCoachPanel(true);
+    await sendInteractionToServer('get_coach_tip', '');
+  };
+
+  const handleInjectProviderResponse = async (type) => {
+    await sendInteractionToServer('inject_provider_response', type);
+  };
+
+  const handleMoveToNextPhase = async () => {
+    if (encounterState.currentPhase === 0) {
+      setEncounterState(prev => ({ ...prev, currentPhase: 1 }));
+      setMessages((prev) => [...prev, {text: `COACH: You've started Phase 1: ${ENCOUNTER_PHASES_CLIENT[1].name}. ${ENCOUNTER_PHASES_CLIENT[1].coachPrompt || ''}`, from: 'coach'}]);
+      return;
+    }
+    await sendInteractionToServer('move_to_next_phase', '');
+  };
+
+  const getProgressPercentage = () => {
+    const totalPhases = Object.keys(ENCOUNTER_PHASES_CLIENT).length - 2;
+    const currentProgress = Math.max(0, encounterState.currentPhase - 1);
+    return Math.min(100, (currentProgress / totalPhases) * 100);
+  };
+
+  const getScoreColor = (score, maxScore) => {
+    if (maxScore === 0) return '#64748b';
+    const percentage = (score / maxScore) * 100;
+    if (percentage >= 80) return '#059669';
+    if (percentage >= 60) return '#d97706';
+    return '#dc2626';
+  };
+
+  const downloadTranscript = () => {
+    const transcriptContent = messages.map((msg) => {
+      const cleanText = msg.text.replace(/\*\*(.*?)\*\*/g, '$1');
+      return `[${msg.from.toUpperCase()}] ${cleanText}`;
+    }).join('\n\n');
+
+    let scoreSummary = '\n\n--- ENCOUNTER SUMMARY ---\n';
+    scoreSummary += `Total Score: ${encounterState.currentCumulativeScore} / ${encounterState.totalPossibleScore}\n\n`;
+
+    if (typeof encounterState.phaseScores === 'object' && encounterState.phaseScores !== null) {
+      Object.entries(encounterState.phaseScores).forEach(([phaseName, phaseCategoryScores]) => {
+        if (phaseCategoryScores) {
+          scoreSummary += `\n--- ${phaseName} Score ---\n`;
+          Object.entries(PHASE_RUBRIC_DEFINITIONS).forEach(([catKey, catDef]) => {
+            const score = phaseCategoryScores[catKey];
+            if (score) {
+              scoreSummary += `${catDef.label}: ${score.points}/${catDef.max} - ${score.justification}\n`;
+            }
+          });
+        }
+      });
+    }
+
+    if (overallFeedback) {
+      scoreSummary += `\n\n--- OVERALL FEEDBACK ---\n${overallFeedback}\n`;
+    }
+
+    const blob = new Blob([transcriptContent + scoreSummary], {type: 'text/plain;charset=utf-8'});
+    const today = new Date();
+    const dateString = today.toISOString().slice(0, 10);
+    const fileName = `ECHO_Encounter_Transcript_${patientState?.name?.replace(/\s/g, '_') || 'unknown_patient'}_${dateString}.txt`;
+    const link = document.createElement('a');
+    link.href = URL.createObjectURL(blob);
+    link.download = fileName;
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    URL.revokeObjectURL(link.href);
+  };
+
+  useEffect(() => {
+    if (!patientState && predefinedPatients.length > 0) {
+      const patient = predefinedPatients[0];
+      const initialCoachMessage = ENCOUNTER_PHASES_CLIENT[0].coachIntro(patient);
+      setPatientState(patient);
+      setMessages([{ text: initialCoachMessage, from: 'coach' }]);
+      setSelectedPatientIndex('0');
+    }
+  }, [patientState]);
+
+  useEffect(() => {
+    refreshUserPatients();
+  }, [refreshUserPatients]);
+
+  return {
+    messages,
+    conversationHistoryForAPI,
+    patientState,
+    inputValue,
+    isLoading,
+    selectedPatientIndex,
+    error,
+    showCoachPanel,
+    showFullPatientInfo,
+    showScoringModal,
+    encounterState,
+    overallFeedback,
+    userPatients,
+    refreshUserPatients,
+    setInputValue,
+    setShowFullPatientInfo,
+    setShowScoringModal,
+    setShowCoachPanel,
+    setSelectedPatientIndex,
+    resetSimulation,
+    loadPatient,
+    handlePredefinedPatientChange,
+    sendInteractionToServer,
+    handleSendMessage,
+    handleCoachTipRequest,
+    handleInjectProviderResponse,
+    handleMoveToNextPhase,
+    getProgressPercentage,
+    getScoreColor,
+    downloadTranscript,
+  };
+};

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -1,0 +1,46 @@
+export const ENCOUNTER_PHASES_CLIENT = {
+  0: {
+    name: "Introduction & Initial Presentation",
+    maxScore: 0,
+    coachIntro: (patient) => `Welcome to ECHO! You're about to meet **${patient.name}**, a **${patient.age}**-year-old. Their main complaint is: "${patient.mainComplaint}". Your goal is to conduct a complete clinical encounter adhering to the Patient-Centered / Biopsychosocial model. Let's begin with **Phase 1: Initiation and Building the Relationship**. What is your first step?`
+  },
+  1: { name: "Initiation & Building the Relationship", maxScore: 5 },
+  2: { name: "Information Gathering & History Taking", maxScore: 5 },
+  3: { name: "Physical Examination", maxScore: 5 },
+  4: { name: "Assessment & Plan / Shared Decision-Making", maxScore: 5 },
+  5: { name: "Closure", maxScore: 5 },
+  6: { name: "Encounter Complete", maxScore: 0 },
+};
+
+export const PHASE_RUBRIC_DEFINITIONS = {
+  communication: {
+    label: "Communication",
+    desc: "Provider demonstrates clear, appropriate language, active listening, and effective questioning techniques. Messages are easy to understand for the patient.",
+    max: 1,
+    icon: "💬",
+  },
+  trustRapport: {
+    label: "Trust & Rapport",
+    desc: "Provider establishes an empathetic and respectful connection with the patient, builds trust, and manages emotions effectively, fostering an open environment.",
+    max: 1,
+    icon: "🤝",
+  },
+  accuracy: {
+    label: "Accuracy",
+    desc: "Provider asks clinically relevant questions, gathers precise and complete information, and identifies key symptoms/history details crucial for diagnosis.",
+    max: 1,
+    icon: "🎯",
+  },
+  culturalHumility: {
+    label: "Cultural Humility",
+    desc: "Provider explores patient's ideas, beliefs, and cultural context respectfully, avoids assumptions, and acknowledges cultural factors influencing health/illness and decision-making.",
+    max: 1,
+    icon: "🌍",
+  },
+  sharedUnderstanding: {
+    label: "Shared Understanding",
+    desc: "Provider ensures patient comprehension of information and the management plan, actively involves the patient in decisions, and effectively uses techniques like teach-back.",
+    max: 1,
+    icon: "🔄",
+  },
+};


### PR DESCRIPTION
## Summary
- centralize encounter phases and rubric definitions in `src/utils/constants.js`
- add `useSimulation` hook to manage simulation state and API calls
- update `SimulationPage` to consume shared constants

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688b8052e88c832d9e65290b72ef89e0