### PR TITLE
refactor: centralize global styles

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,6 +1,5 @@
 import React from "react";
 import { Routes, Route, Link } from "react-router-dom";
-import './index.css';
 
 // Import all ECHO application components
 import SimulationPage from "./SimulationPage";

--- a/src/HelpPage.js
+++ b/src/HelpPage.js
@@ -1,5 +1,4 @@
 import React, { useState } from 'react';
-import './index.css';
 
 /**
  * ECHO Help Page Component

--- a/src/PatientIntakeForm.js
+++ b/src/PatientIntakeForm.js
@@ -1,5 +1,4 @@
 import React, { useState, useEffect } from 'react';
-import './index.css';
 
 // Import existing patient data files
 import predefinedPatients from './patients/predefinedPatients.json';

--- a/src/SimulationPage.js
+++ b/src/SimulationPage.js
@@ -1,6 +1,5 @@
 import React, { useEffect, useRef } from "react";
 import predefinedPatients from "./patients/predefinedPatients.json";
-import "./index.css";
 import { ENCOUNTER_PHASES_CLIENT, PHASE_RUBRIC_DEFINITIONS } from "./utils/constants";
 import { useSimulation } from "./hooks/useSimulation";
 


### PR DESCRIPTION
## Summary
- centralize global CSS import in index.js
- remove redundant index.css imports from feature components

## Testing
- `npm test --silent`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688b8794f17c832d9e3c81f76d9fa8e1