### PR TITLE
Remove unused variables from SimulationPage

### DIFF
--- a/src/SimulationPage.js
+++ b/src/SimulationPage.js
@@ -28,7 +28,6 @@ function SimulationPage() {
 
   const {
     messages,
-    conversationHistoryForAPI,
     patientState,
     inputValue,
     isLoading,
@@ -45,11 +44,7 @@ function SimulationPage() {
     setShowFullPatientInfo,
     setShowScoringModal,
     setShowCoachPanel,
-    setSelectedPatientIndex,
-    resetSimulation,
-    loadPatient,
     handlePredefinedPatientChange,
-    sendInteractionToServer,
     handleSendMessage,
     handleCoachTipRequest,
     handleInjectProviderResponse,


### PR DESCRIPTION
## Summary
- remove unused hook outputs from `SimulationPage`

## Testing
- `npx eslint src/SimulationPage.js`
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_688b95634328832d8a123db073c27f02