### PR TITLE
refactor: centralize component styles

### DIFF
--- a/src/PatientIntakeForm.js
+++ b/src/PatientIntakeForm.js
@@ -606,13 +606,11 @@ function PatientIntakeForm() {
 
       {/* Tooltip Popup (renders when activeTooltip is set) */}
       {activeTooltip && FIELD_TOOLTIPS[activeTooltip] && (
-        <div 
+        <div
           className="tooltip-popup"
           style={{
-            position: 'fixed',
-            left: `${tooltipPosition.x}px`,
-            top: `${tooltipPosition.y}px`,
-            zIndex: 1000
+            '--tooltip-left': `${tooltipPosition.x}px`,
+            '--tooltip-top': `${tooltipPosition.y}px`
           }}
         >
           <h4 className="tooltip-title">{FIELD_TOOLTIPS[activeTooltip].title}</h4>
@@ -628,7 +626,7 @@ function PatientIntakeForm() {
       )}
 
       <div className="help-container">
-        <div className="help-section" style={{flex: '1'}}>
+        <div className="help-section flex-1">
           
           {/* ============================================================ */}
           {/* AI-POWERED FIELD POPULATION SECTION */}
@@ -659,7 +657,7 @@ function PatientIntakeForm() {
               rows="4"
             />
             
-            <div style={{display: 'flex', flexDirection: 'column', gap: '10px'}}>
+            <div className="column-gap-10">
               <button
                 className="submit-button"
                 onClick={handleAiPopulate}
@@ -669,13 +667,13 @@ function PatientIntakeForm() {
               </button>
               
               {successMessage && (
-                <p className="loading-message" style={{color: 'var(--success-color)', margin: '0'}}>
+                <p className="loading-message text-success no-margin">
                   {successMessage}
                 </p>
               )}
-              
+
               {aiError && (
-                <p className="error-message" style={{margin: '0'}}>
+                <p className="error-message no-margin">
                   {aiError}
                 </p>
               )}
@@ -765,7 +763,7 @@ function PatientIntakeForm() {
 
             {/* Success message display */}
             {successMessage && (
-              <p className="loading-message" style={{color: 'var(--success-color)'}}>
+              <p className="loading-message text-success">
                 {successMessage}
               </p>
             )}
@@ -775,7 +773,7 @@ function PatientIntakeForm() {
         {/* ============================================================ */}
         {/* GENERATED PATIENT PREVIEW PANEL */}
         {/* ============================================================ */}
-        <div className="patient-info-panel" style={{width: '400px'}}>
+        <div className="patient-info-panel">
           {generatedPatient ? (
             <div>
               <h3 className="patient-info-title">Generated Patient</h3>
@@ -829,16 +827,15 @@ function PatientIntakeForm() {
               </div>
               
               {/* Export button */}
-              <button 
-                className="control-button" 
+              <button
+                className="control-button mt-10"
                 onClick={downloadPatientJson}
-                style={{marginTop: '10px'}}
               >
                 Download JSON
               </button>
               
               {/* Usage instructions */}
-              <p className="loading-message" style={{fontSize: '0.8em', marginTop: '15px'}}>
+              <p className="loading-message small-text mt-15">
                 This patient has been saved locally and will appear as "User: {generatedPatient.name}" in the simulation page dropdown.
               </p>
             </div>

--- a/src/SimulationPage.js
+++ b/src/SimulationPage.js
@@ -50,7 +50,7 @@ function SimulationPage() {
     handleInjectProviderResponse,
     handleMoveToNextPhase,
     getProgressPercentage,
-    getScoreColor,
+    getScoreClass,
     downloadTranscript,
   } = useSimulation();
 
@@ -151,7 +151,7 @@ function SimulationPage() {
               <div className="score-summary-card">
                 <h3>Overall Performance</h3>
                 <div className="score-display">
-                  <span className="score-number" style={{color: getScoreColor(totalScore, maxPossibleScore)}}>
+                  <span className={`score-number ${getScoreClass(totalScore, maxPossibleScore)}`}>
                     {totalScore}
                   </span>
                   <span className="score-divider">/</span>
@@ -252,9 +252,9 @@ function SimulationPage() {
                 </div>
               </div>
               <div className="progress-bar">
-                <div 
-                  className="progress-fill" 
-                  style={{width: `${progressPercentage}%`}}
+                <div
+                  className="progress-fill"
+                  style={{ '--progress-width': `${progressPercentage}%` }}
                 ></div>
               </div>
             </div>
@@ -263,7 +263,7 @@ function SimulationPage() {
             <div className="score-display-header">
               <div className="score-card-mini">
                 <div className="score-main">
-                  <span style={{color: getScoreColor(totalScore, maxPossibleScore)}}>
+                  <span className={getScoreClass(totalScore, maxPossibleScore)}>
                     {totalScore}
                   </span>
                   <span className="score-divider">/</span>
@@ -423,7 +423,7 @@ function SimulationPage() {
                 <div className="results-content">
                   <div className="final-score-display">
                     <div className="score-circle">
-                      <div className="score-value" style={{color: getScoreColor(totalScore, maxPossibleScore)}}>
+                      <div className={`score-value ${getScoreClass(totalScore, maxPossibleScore)}`}>
                         {totalScore}
                       </div>
                       <div className="score-total">out of {maxPossibleScore}</div>

--- a/src/hooks/useSimulation.js
+++ b/src/hooks/useSimulation.js
@@ -195,12 +195,12 @@ export const useSimulation = () => {
     return Math.min(100, (currentProgress / totalPhases) * 100);
   };
 
-  const getScoreColor = (score, maxScore) => {
-    if (maxScore === 0) return '#64748b';
+  const getScoreClass = (score, maxScore) => {
+    if (maxScore === 0) return 'score-neutral';
     const percentage = (score / maxScore) * 100;
-    if (percentage >= 80) return '#059669';
-    if (percentage >= 60) return '#d97706';
-    return '#dc2626';
+    if (percentage >= 80) return 'score-good';
+    if (percentage >= 60) return 'score-average';
+    return 'score-poor';
   };
 
   const downloadTranscript = () => {
@@ -286,7 +286,7 @@ export const useSimulation = () => {
     handleInjectProviderResponse,
     handleMoveToNextPhase,
     getProgressPercentage,
-    getScoreColor,
+    getScoreClass,
     downloadTranscript,
   };
 };

--- a/src/index.css
+++ b/src/index.css
@@ -364,6 +364,7 @@ html, body {
 }
 
 .progress-fill {
+  width: var(--progress-width, 0%);
   background: rgba(255, 255, 255, 0.9);
   height: 100%;
   border-radius: 4px;
@@ -811,6 +812,7 @@ html, body {
 /* Patient Info Panel */
 .patient-info-panel {
   background: white;
+  width: 400px;
   border-radius: var(--radius-xl);
   padding: var(--spacing-xl);
   box-shadow: 0 4px 20px var(--shadow-color);
@@ -879,7 +881,9 @@ html, body {
 }
 
 .tooltip-popup {
-  position: absolute;
+  position: fixed;
+  left: var(--tooltip-left, 0);
+  top: var(--tooltip-top, 0);
   background: white;
   border: 1px solid var(--border-color);
   border-radius: var(--radius-lg);
@@ -1026,6 +1030,18 @@ html, body {
 
 .w-full { width: 100%; }
 .h-full { height: 100%; }
+
+.flex-1 { flex: 1; }
+.column-gap-10 { display: flex; flex-direction: column; gap: 10px; }
+.text-success { color: var(--success-color); }
+.no-margin { margin: 0; }
+.mt-10 { margin-top: 10px; }
+.mt-15 { margin-top: 15px; }
+.small-text { font-size: 0.8em; }
+.score-good { color: #059669; }
+.score-average { color: #d97706; }
+.score-poor { color: #dc2626; }
+.score-neutral { color: #64748b; }
 
 /* ========================================================================== */
 /* COACH PANEL STYLES */


### PR DESCRIPTION
## Summary
- replace inline score coloring with CSS classes driven by `getScoreClass`
- move tooltip positioning, patient info panel width, and message styles into shared CSS
- introduce utility classes and variable-driven progress bar width

## Testing
- `npm test -- --watch=false`

------
https://chatgpt.com/codex/tasks/task_e_688b94cefef4832da9ebe03d3bec6320