### PR TITLE
Fix PatientIntake form overflow

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -265,7 +265,7 @@ html, body {
 .help-container {
   display: flex;
   flex-direction: column;
-  height: 100%;
+  flex: 1;
   padding: var(--spacing-xl);
   overflow-y: auto;
 }


### PR DESCRIPTION
## Summary
- prevent PatientIntake form content from being cut off by using flex layout instead of fixed height

## Testing
- `npm test -- --watchAll=false` *(fails: No tests found, exiting with code 1)*

------
https://chatgpt.com/codex/tasks/task_e_688ba3d698bc832d9accf681c1a6344a