### PR TITLE
chore: clean up config and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,10 +69,10 @@ ECHO is an AI-powered clinical simulation platform that helps healthcare provide
 
 ## Running Tests
 
-The project uses the default Create React App testing setup.
+The project uses the default Create React App testing setup. No tests are defined yet, but the test command will exit successfully.
 
 ```
-npm test -- --watchAll=false
+npm test
 ```
 
 ## License

--- a/functions/handlers.js
+++ b/functions/handlers.js
@@ -43,7 +43,7 @@ async function handleGeneratePatientFromForm(req, res, geminiApiSecret) {
 
     const patientProfile = {
       name: formData.name || 'Custom Patient',
-      age: parseInt(formData.age) || 35,
+      age: parseInt(formData.age, 10) || 35,
       genderIdentity: formData.genderIdentity || 'Not specified',
       pronouns: formData.pronouns || 'they/them',
       nativeLanguage: formData.nativeLanguage || 'English',

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "build": "react-scripts build",
     "predeploy": "npm run build",
     "deploy": "gh-pages -d build",
-    "test": "react-scripts test",
+    "test": "react-scripts test --watchAll=false --passWithNoTests",
     "eject": "react-scripts eject"
   },
   "eslintConfig": {

--- a/src/firebase.js
+++ b/src/firebase.js
@@ -1,8 +1,6 @@
 import { initializeApp } from 'firebase/app';
 
-// TODO: Add SDKs for Firebase products that you want to use
-// https://firebase.google.com/docs/web/setup#available-libraries
-
+// Firebase project configuration
 const firebaseConfig = {
   apiKey: 'AIzaSyC6i1I_kXZu9LoUHH5FpoTMlXN-9gbglEI',
   authDomain: 'echo-d825e.firebaseapp.com',


### PR DESCRIPTION
## Summary
- remove leftover Firebase TODO
- ensure age parsing uses base-10
- streamline test script and docs to pass with no tests

## Testing
- `npm test`
- `npm --prefix functions run lint`
- `npm --prefix functions test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_688bb7e9d27c832da6603887c3e50171