### PR TITLE
Clean up footers and standardize ECHO branding

### DIFF
--- a/about.html
+++ b/about.html
@@ -505,10 +505,7 @@
 
                 <div class="footer-section">
                     <h3>Contact Info</h3>
-                    <p>Email: wgr@jhu.edu</p>
-                    <p>Lead: Charbel Maroun</p>
-                    <p>charbel.maroun0702@gmail.com</p>
-                    <p>Johns Hopkins University</p>
+                    <p>Email: info@echosimulator.org</p>
                 </div>
             </div>
 

--- a/help.html
+++ b/help.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Help - Echo Medical Simulator</title>
+    <title>Help - Project ECHO</title>
     <link rel="stylesheet" href="css/style.css" />
     <link rel="icon" href="favicon.ico" />
   </head>
@@ -28,11 +28,11 @@
     <main>
       <section class="card">
         <h1>Help</h1>
-        <p>Resources and guidance for using the Echo simulator.</p>
+        <p>Resources and guidance for using the ECHO simulator.</p>
       </section>
     </main>
     <footer>
-      <p>&copy; 2025 Echo Training</p>
+      <p>&copy; 2025 Project ECHO</p>
     </footer>
   </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -472,8 +472,6 @@
                 <div class="footer-section">
                     <h3>Contact Info</h3>
                     <p>Email: info@echosimulator.org</p>
-                    <p>Phone: (555) 123-4567</p>
-                    <p>Address: Medical Innovation Center</p>
                 </div>
             </div>
             

--- a/references.html
+++ b/references.html
@@ -336,10 +336,7 @@
                 
                 <div class="footer-section">
                     <h3>Contact Info</h3>
-                    <p>Email: wgr@jhu.edu</p>
-                    <p>Lead: Charbel Maroun</p>
-                    <p>charbel.maroun0702@gmail.com</p>
-                    <p>Johns Hopkins University</p>
+                    <p>Email: info@echosimulator.org</p>
                 </div>
             </div>
             

--- a/simulator-help.html
+++ b/simulator-help.html
@@ -693,10 +693,7 @@
                 
                 <div class="footer-section">
                     <h3>Contact Info</h3>
-                    <p>Email: wgr@jhu.edu</p>
-                    <p>Lead: Charbel Maroun</p>
-                    <p>charbel.maroun0702@gmail.com</p>
-                    <p>Johns Hopkins University</p>
+                    <p>Email: info@echosimulator.org</p>
                 </div>
             </div>
             


### PR DESCRIPTION
## Summary
- Replace personal contact info in footers with `info@echosimulator.org`
- Remove fictitious phone and address entries from site footer
- Update Help page to use Project ECHO branding consistently

## Testing
- `npm test` *(fails: Could not read package.json)*
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_688bc3569318832d9aea2ec2215f5fb3