### PR TITLE
chore: remove tagline from site footer

### DIFF
--- a/about.html
+++ b/about.html
@@ -484,7 +484,7 @@
             <div class="footer-content">
                 <div class="footer-section">
                     <h3>Project ECHO</h3>
-                    <p>Breaking down communication barriers in healthcare through AI-powered simulation. "Because hearing is not listening." - Empowering culturally responsive care for all patients.</p>
+                    <p>Empowering culturally responsive care for all patients.</p>
                 </div>
 
                 <div class="footer-section">

--- a/index.html
+++ b/index.html
@@ -450,7 +450,7 @@
             <div class="footer-content">
                 <div class="footer-section">
                     <h3>Project ECHO</h3>
-                    <p>Breaking down communication barriers in healthcare through AI-powered simulation. "Because hearing is not listening." - Empowering culturally responsive care for all patients.</p>
+                    <p>Empowering culturally responsive care for all patients.</p>
                 </div>
                 
                 <div class="footer-section">

--- a/references.html
+++ b/references.html
@@ -315,7 +315,7 @@
             <div class="footer-content">
                 <div class="footer-section">
                     <h3>Project ECHO</h3>
-                    <p>Breaking down communication barriers in healthcare through AI-powered simulation. "Because hearing is not listening." - Empowering culturally responsive care for all patients.</p>
+                    <p>Empowering culturally responsive care for all patients.</p>
                 </div>
                 
                 <div class="footer-section">

--- a/simulator-help.html
+++ b/simulator-help.html
@@ -672,7 +672,7 @@
             <div class="footer-content">
                 <div class="footer-section">
                     <h3>Project ECHO</h3>
-                    <p>Breaking down communication barriers in healthcare through AI-powered simulation. "Because hearing is not listening." - Empowering culturally responsive care for all patients.</p>
+                    <p>Empowering culturally responsive care for all patients.</p>
                 </div>
                 
                 <div class="footer-section">


### PR DESCRIPTION
## Summary
- remove outdated tagline from footer on all pages

## Testing
- `python - <<'PY'
import compileall, sys
sys.exit(0 if compileall.compile_dir('.', quiet=1) else 1)
PY`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688bd3cea8b0832d8ea141e6a593776d